### PR TITLE
Fix spider: Atlantic City

### DIFF
--- a/city_scrapers/spiders/atconj_Atlantic_City.py
+++ b/city_scrapers/spiders/atconj_Atlantic_City.py
@@ -96,7 +96,7 @@ class AtlanticCitySpider(CityScrapersSpider):
         )
 
         meeting["status"] = self._get_status(meeting_detail)
-        meeting["id"] = int(item["id"])
+        meeting["id"] = self._get_id(meeting)
 
         yield meeting
 

--- a/tests/test_atconj_Atlantic_City.py
+++ b/tests/test_atconj_Atlantic_City.py
@@ -63,7 +63,9 @@ def test_all_day():
 
 
 def test_id():
-    assert parsed_items[0]["id"] == 429
+    assert (
+        parsed_items[0]["id"] == "atconj_Atlantic_City/202406261700/x/citistat_meeting"
+    )
 
 
 def test_status():


### PR DESCRIPTION
## What does this PR do?
- Use the default method `_get_id` to build meeting ID for spider Atlantic City.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated meeting ID generation method for Atlantic City spider
	- Modified ID format for meeting items from numeric to a specific string representation

- **Tests**
	- Updated test case to reflect new meeting ID format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->